### PR TITLE
Add option to `block commit` in `newline-at-eof` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,26 @@ If unspecified, it defaults to the following message:
       ]
     COMMIT_MESSAGE: 'Fix formatting'
 ```
+
+Or it can be used in conjunction with other formatting tools and commit using third-party GitHub commit action.
+
+```yml
+- name: Check newline at EOF
+  uses: gps/newline-at-eof@master
+  with:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    IGNORE_FILE_PATTERNS: |
+      [
+        "dist/.*",
+        "package-lock.json"
+      ]
+    BLOCK_COMMIT: true
+
+- name: Run formatter
+  run: npm run format
+
+- name: Commit changes
+  uses: stefanzweifel/git-auto-commit-action@v4
+  with:
+    commit_message: Format code
+```

--- a/README.md
+++ b/README.md
@@ -20,15 +20,26 @@ Path to ignore while checkking for newline at EOF.
 
 ### `COMMIT_MESSAGE`
 
-Commit message to post when making a fix commit
+Commit message to post when making a fix commit.
 
-**Required**
+**Optional**
 
 **Default Value**
 
 If unspecified, it defaults to the following message:
 
 "Fix formatting"
+
+### `COMMIT_AND_PUSH_CHANGES`
+
+Whether to commit and push the changes to the remote.
+It takes boolean values.
+
+**Optional**
+
+**Default Value**
+
+If unspecified, it defaults to true.
 
 ## Example Usage
 
@@ -57,7 +68,7 @@ Or it can be used in conjunction with other formatting tools and commit using th
         "dist/.*",
         "package-lock.json"
       ]
-    BLOCK_COMMIT: true
+    COMMIT_AND_PUSH_CHANGES: false
 
 - name: Run formatter
   run: npm run format

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   COMMIT_MESSAGE:
     description: Commit message to use when commiting fixes.
     required: false
-  BLOCK_COMMIT:
+  COMMIT_AND_PUSH_CHANGES:
     description: Prevent actoion from making a commit and pushing the changes to remote.
     required: false
 runs:

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: Commit message to use when commiting fixes.
     required: false
   COMMIT_AND_PUSH_CHANGES:
-    description: Prevent actoion from making a commit and pushing the changes to remote.
+    description: Prevent action from making a commit and pushing the changes to remote.
     required: false
 runs:
   using: node12

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   COMMIT_MESSAGE:
     description: Commit message to use when commiting fixes.
     required: false
+  BLOCK_COMMIT:
+    description: Prevent actoion from making a commit and pushing the changes to remote.
+    required: false
 runs:
   using: node12
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -124,6 +124,7 @@ async function run() {
   const token = core.getInput('GH_TOKEN');
   let ignorePaths = core.getInput('IGNORE_FILE_PATTERNS');
   let commitMessage = core.getInput('COMMIT_MESSAGE');
+  let commitAndPushChanges = core.getInput('COMMIT_AND_PUSH_CHANGES');
 
   if (!ignorePaths) {
     ignorePaths = [];
@@ -138,6 +139,10 @@ async function run() {
     commitMessage = 'Fix formatting';
   }
 
+  if (commitAndPushChanges !== false) {
+    commitAndPushChanges = true;
+  }
+  
   try {
     // Extract branch name if pull request else break execution.
     let branch;
@@ -177,8 +182,10 @@ async function run() {
     // Log Changed files
     core.info('Files to commit: ' + JSON.stringify(filesToCommit));
 
-    // Generate DIff and commit changes
-    await commitChanges(filesToCommit, commitMessage, git, branch);
+    if (commitAndPushChanges) {
+      // Generate DIff and commit changes
+      await commitChanges(filesToCommit, commitMessage, git, branch);
+    }
   } catch (error) {
     core.setFailed(error);
   }

--- a/index.js
+++ b/index.js
@@ -117,6 +117,7 @@ async function run() {
   const token = core.getInput('GH_TOKEN');
   let ignorePaths = core.getInput('IGNORE_FILE_PATTERNS');
   let commitMessage = core.getInput('COMMIT_MESSAGE');
+  const block_commit = core.getInput('BLOCK_COMMIT');
 
   if (!ignorePaths) {
     ignorePaths = [];
@@ -171,7 +172,9 @@ async function run() {
     core.info('Files to commit: ' + JSON.stringify(filesToCommit));
 
     // Generate DIff and commit changes
-    await commitChanges(filesToCommit, commitMessage, git, branch);
+    if (!block_commit) {
+      await commitChanges(filesToCommit, commitMessage, git, branch);
+    }
   } catch (error) {
     core.setFailed(error);
   }

--- a/index.js
+++ b/index.js
@@ -171,8 +171,8 @@ async function run() {
     // Log Changed files
     core.info('Files to commit: ' + JSON.stringify(filesToCommit));
 
-    // Generate DIff and commit changes
     if (!block_commit) {
+      // Generate DIff and commit changes
       await commitChanges(filesToCommit, commitMessage, git, branch);
     }
   } catch (error) {

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ async function run() {
   const token = core.getInput('GH_TOKEN');
   let ignorePaths = core.getInput('IGNORE_FILE_PATTERNS');
   let commitMessage = core.getInput('COMMIT_MESSAGE');
-  const block_commit = core.getInput('BLOCK_COMMIT');
+  let commitAndPushChanges = core.getInput('COMMIT_AND_PUSH_CHANGES');
 
   if (!ignorePaths) {
     ignorePaths = [];
@@ -132,6 +132,10 @@ async function run() {
     commitMessage = 'Fix formatting';
   }
 
+  if (commitAndPushChanges !== false) {
+    commitAndPushChanges = true;
+  }
+  
   try {
     // Extract branch name if pull request else break execution.
     let branch;
@@ -171,7 +175,7 @@ async function run() {
     // Log Changed files
     core.info('Files to commit: ' + JSON.stringify(filesToCommit));
 
-    if (!block_commit) {
+    if (commitAndPushChanges) {
       // Generate DIff and commit changes
       await commitChanges(filesToCommit, commitMessage, git, branch);
     }


### PR DESCRIPTION
Adds option to skip committing and pushing the code to remote.